### PR TITLE
Support https proxy 

### DIFF
--- a/cmd/kn/app/options.go
+++ b/cmd/kn/app/options.go
@@ -14,6 +14,7 @@ type KnOptions struct {
 	Host             string
 	Headers          []string
 	Local            string // local address, for example 3000/:3000/192.168.0.12:8000 are all valid
+	Protocol         string
 	KeepAlive        time.Duration
 	MaxRetryCount    int
 	MaxRetryInterval time.Duration
@@ -30,6 +31,7 @@ func NewKnOptions() *KnOptions {
 		MaxRetryInterval: 5 * time.Minute,
 		MaxRetryCount:    0,
 		KeepAlive:        1 * time.Minute,
+		Protocol:         "http",
 	}
 }
 
@@ -43,6 +45,7 @@ func (k *KnOptions) Flags() *pflag.FlagSet {
 	fs.StringVarP(&k.Namespace, "namespace", "n", k.Namespace, "[Kubernetes Only] Namespace of the service.")
 	fs.BoolVarP(&k.Daemon, "daemon", "d", k.Daemon, "Run as a deployment in the cluster.")
 	fs.StringVar(&k.Server, "server", k.Server, "Available kunnel server address.")
+	fs.StringVar(&k.Protocol, "protocol", k.Protocol, "Proxied service's protocol, only http and https are supported.")
 	fs.StringVar(&k.KubeConfig, "kubeconfig", fmt.Sprintf("%s/.kube/config", homeDir), "[Kubernetes Only] Location of the kubeconfig")
 	fs.StringVarP(&k.Service, "service", "s", k.Service, "[Kubernetes Only] Service name to be proxied, only services with cluster ip are supported.")
 	fs.StringVar(&k.Host, "host", k.Host, "Override request host field when proxied to destintation.")

--- a/cmd/kn/app/template.go
+++ b/cmd/kn/app/template.go
@@ -40,7 +40,7 @@ var DeploymentTemplate = &v1.Deployment{
 	},
 }
 
-func NewDeployment(namespace, service, localhost, server string, localport int, host string, headers []string) *v1.Deployment {
+func NewDeployment(namespace, service, localhost, server string, localport int, host, protocol string, headers []string) *v1.Deployment {
 	deployment := DeploymentTemplate.DeepCopy()
 	deployment.Name = fmt.Sprintf("kunnel-%s", service)
 	deployment.Namespace = namespace
@@ -49,6 +49,10 @@ func NewDeployment(namespace, service, localhost, server string, localport int, 
 	command = append(command, "--server", server, "--local", fmt.Sprintf("%s:%d", localhost, localport))
 	if len(host) != 0 {
 		command = append(command, "--host", host)
+	}
+
+	if len(protocol) != 0 {
+		command = append(command, "--protocol", protocol)
 	}
 
 	for _, header := range headers {

--- a/cmd/kn/main.go
+++ b/cmd/kn/main.go
@@ -76,10 +76,10 @@ func main() {
 			}
 
 			if knOptions.Daemon {
-				return StartInCluster(kubeClient, ctx, knOptions.Namespace, knOptions.Service, knOptions.Server, service.Spec.ClusterIP, knOptions.Port, knOptions.Host, knOptions.Headers)
+				return StartInCluster(kubeClient, ctx, knOptions.Namespace, knOptions.Service, knOptions.Server, service.Spec.ClusterIP, knOptions.Port, knOptions.Host, knOptions.Protocol, knOptions.Headers)
 			}
 
-			return Start(ctx, service.Spec.ClusterIP, knOptions.Port, knOptions.Host, knOptions.Server, headers)
+			return Start(ctx, service.Spec.ClusterIP, knOptions.Port, knOptions.Host, knOptions.Server, knOptions.Protocol, headers)
 		},
 	}
 
@@ -91,13 +91,14 @@ func main() {
 	}
 }
 
-func Start(ctx context.Context, localhost string, localport int, host, server string, headers map[string]string) error {
+func Start(ctx context.Context, localhost string, localport int, host, server, protocol string, headers map[string]string) error {
 	config := &agent.Config{
 		Name:      "dummy",
 		LocalHost: localhost,
 		LocalPort: localport,
 		Host:      host,
 		Hedaers:   headers,
+		Protocol:  protocol,
 	}
 
 	agent := agent.NewClient(config, time.Second*3, 20, time.Minute*5, server)
@@ -108,8 +109,8 @@ func Start(ctx context.Context, localhost string, localport int, host, server st
 	return agent.Wait()
 }
 
-func StartInCluster(kubeClient kubernetes.Interface, ctx context.Context, namespace, service, server string, localhost string, localport int, host string, headers []string) error {
-	deployment := app.NewDeployment(namespace, service, localhost, server, localport, host, headers)
+func StartInCluster(kubeClient kubernetes.Interface, ctx context.Context, namespace, service, server string, localhost string, localport int, host, protocol string, headers []string) error {
+	deployment := app.NewDeployment(namespace, service, localhost, server, localport, host, protocol, headers)
 
 	_, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, deployment.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -16,6 +16,8 @@ type Config struct {
 
 	Host string
 
+	Protocol string
+
 	Hedaers map[string]string
 }
 

--- a/pkg/proxy/http_proxy.go
+++ b/pkg/proxy/http_proxy.go
@@ -15,13 +15,14 @@ type HttpProxy struct {
 	name       string
 	port       int
 	host       string
+	protocol   string
 	server     *http.Server
 	httpClient *http.Client
 	proxyHost  string
 	headers    map[string]string
 }
 
-func NewHttpProxy(name, host string, port int, proxyHost string, headers map[string]string, transport *http.Transport) *HttpProxy {
+func NewHttpProxy(name, host, protocol string, port int, proxyHost string, headers map[string]string, transport *http.Transport) *HttpProxy {
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%d", port),
 	}
@@ -30,6 +31,7 @@ func NewHttpProxy(name, host string, port int, proxyHost string, headers map[str
 		name:      name,
 		host:      host,
 		port:      port,
+		protocol:  protocol,
 		headers:   headers,
 		server:    server,
 		proxyHost: proxyHost,
@@ -69,6 +71,7 @@ func (s *HttpProxy) Start(ctx context.Context) error {
 func (s *HttpProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	u := *req.URL
 	u.Host = fmt.Sprintf("%s:%d", s.host, s.port)
+	u.Scheme = s.protocol
 
 	httpProxy := k8sproxy.NewUpgradeAwareHandler(&u, s.httpClient.Transport, false, false, s)
 

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -142,7 +142,13 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		},
 	}
 
-	proxy := NewHttpProxy(config.Name, config.LocalHost, config.LocalPort, config.Host, config.Hedaers, transport)
+	if config.Protocol == "https" {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
+	proxy := NewHttpProxy(config.Name, config.LocalHost, config.Protocol, config.LocalPort, config.Host, config.Hedaers, transport)
 
 	subDomain := s.generateSubDomain() + s.domain
 


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>
Support HTTPS proxy. The certificate verification will be skipped for the target service.

`./kn -n default -s nginx --protocol https`